### PR TITLE
Docs: Fixed broken screenshot links due to case mismatch to render screenshots correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,38 +178,38 @@ LOOK-DGC includes an **AI Solutions** tool group featuring **TruFor**, an AI-bas
 ## 📸 Screenshots
 
 <p align="center">
-  <img src="demo-ss/0_gen.png" alt="General Tools" width="800"/>
+  <img src="Demo-Ss/0_gen.png" alt="General Tools" width="800"/>
   <br><b>📋 General Tools</b>: Original Image, File Digest, Hex Editor, Similar Search
 </p>
 
 
 <p align="center">
-  <img src="demo-ss/2_ins.png" alt="Visual Inspection" width="800"/>
+  <img src="Demo-Ss/2_ins.png" alt="Visual Inspection" width="800"/>
   <br><b>🔬 Visual Inspection</b>: Magnifier, Histogram, Reference Comparison
 </p>
 
 <p align="center">
-  <img src="demo-ss/3_detai.png" alt="Detail Analysis" width="800"/>
+  <img src="Demo-Ss/3_detai.png" alt="Detail Analysis" width="800"/>
   <br><b>🎯 Detail Analysis</b>: Gradient, Edge Filter, Wavelet, Frequency Split
 </p>
 
 <p align="center">
-  <img src="demo-ss/4_clour.png" alt="Color Analysis" width="800"/>
+  <img src="Demo-Ss/4_clour.png" alt="Color Analysis" width="800"/>
   <br><b>🎨 Color Analysis</b>: RGB/HSV Plots, Space Conversion, PCA, Statistics
 </p>
 
 <p align="center">
-  <img src="demo-ss/5_noise.png" alt="Noise Analysis" width="800"/>
+  <img src="Demo-Ss/5_noise.png" alt="Noise Analysis" width="800"/>
   <br><b>📡 Noise Analysis</b>: Noise Separation, Min/Max Deviation, Bit Planes
 </p>
 
 <p align="center">
-  <img src="demo-ss/6_jpeg.png" alt="JPEG Analysis" width="800"/>
+  <img src="Demo-Ss/6_jpeg.png" alt="JPEG Analysis" width="800"/>
   <br><b>📷 JPEG Analysis</b>: Quality Estimation, Error Level Analysis
 </p>
 
 <p align="center">
-  <img src="demo-ss/7_tampe.png" alt="Tampering Detection" width="800"/>
+  <img src="Demo-Ss/7_tampe.png" alt="Tampering Detection" width="800"/>
   <br><b>⚠️ Tampering Detection</b>: Copy-Move, Splicing, Resampling, Filtering
 </p>
 


### PR DESCRIPTION
## #3 Issue Summary
Case mismatch between screenshot directory and README image paths

## Description
README embeds screenshots using paths like `demo-ss/0_gen.png`, but the actual directory is `Demo-Ss/`. On case-sensitive systems, these links break.

## Fix
- Updated README paths to match actual directory name
- Verified screenshots render correctly on GitHub

## Testing
- Viewed README locally and confirmed images display

## Fixed issue screenshots

| Screenshot 1 (Before) | Screenshot 2 (After)|
|--------------|--------------|
| <img src="https://github.com/user-attachments/assets/0f4ba0fc-bb98-4e9e-97fe-99895108a2b7"/> | <img src="https://github.com/user-attachments/assets/3a49832a-a2f6-4665-815e-a79b2c7529e8"/> |

