### PR TITLE
Fix misleading HexEd.it offline launcher messages

### DIFF
--- a/launch_look_dgc.py
+++ b/launch_look_dgc.py
@@ -28,10 +28,10 @@ def main():
     online = check_internet()
     if online:
         print("  🌐 Status: Online - Full features available")
-        print("  📡 HexEd.it: Online + Offline cached ready")
+        print("  📡 Hex editor: Online (HexEd.it) + Offline built-in viewer ready")
     else:
-        print("  📡 Status: Offline - Cached features available")
-        print("  💾 HexEd.it: Offline ready (cached)")
+        print("  📡 Status: Offline - Limited features available")
+        print("  💾 Hex editor: Offline built-in viewer ready")
     print()
     
     # Change to the gui directory


### PR DESCRIPTION
Summary:
This PR fixes misleading launcher messages that said HexEd.it was cached for offline use.

Details:
Offline mode actually switches to a separate built-in hex viewer implemented in Python, not a cached HexEd.it instance. The launcher text has been updated to clearly distinguish between:
- Online mode using HexEd.it
- Offline mode using the built-in hex viewer

Files changed:
- launch_look_dgc.py

This change adjust the launcher messages according to the actual application behavior.

Fixes #17 