### PR TITLE
Fix broken Features link in README Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 - [🎯 Introduction](#-introduction)
 - [🚀 Quick Start](#-quick-start)
-- [⚡ Features](#-features)Launch-LOOK-DGC.bat
+- [⚡ Features](#-features)
 - [📸 Screenshots](#-screenshots)
 - [💻 Installation](#-installation)
 - [🐳 Docker Setup](#-docker-setup)


### PR DESCRIPTION
This PR fixes a documentation issue in README.md where the
"⚡ Features" entry in the Table of Contents had accidental
trailing text (`Launch-LOOK-DGC.bat`).

The stray text has been removed so the TOC now correctly
contains only the markdown link.
Fixes #1 