### PR TITLE
feat: Add missing reportlab dependency validation

### DIFF
--- a/launch_look_dgc.py
+++ b/launch_look_dgc.py
@@ -55,7 +55,8 @@ def check_dependencies_basic():
         'astor': 'astor',
         'concurrent-iterator': 'concurrent_iterator',
         'keras-applications': 'keras_applications',
-        'xgboost': 'xgboost'
+        'xgboost': 'xgboost',
+        'reportlab': 'reportlab'
     }
     
     # Try to import tensorflow (optional but important for some features)

--- a/validate_deps.py
+++ b/validate_deps.py
@@ -28,7 +28,8 @@ def get_required_packages() -> Dict[str, str]:
         'astor': 'astor',
         'concurrent-iterator': 'concurrent_iterator',
         'keras-applications': 'keras_applications',
-        'xgboost': 'xgboost'
+        'xgboost': 'xgboost',
+        'reportlab': 'reportlab'
     }
 
 def check_package(package_name: str, import_name: str) -> Tuple[bool, str]:


### PR DESCRIPTION

**issue**:#24


# Description

This PR adds `reportlab` to the dependency validation logic in [launch_look_dgc.py](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/launch_look_dgc.py:0:0-0:0) and [validate_deps.py](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/validate_deps.py:0:0-0:0).

**Reason for change:**
`reportlab` is a required dependency for generating PDF reports (used in [gui/report.py](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/gui/report.py:0:0-0:0) and listed in [gui/requirements.txt](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/gui/requirements.txt:0:0-0:0)). However, it was missing from the runtime dependency checks. This caused the launcher to incorrectly report "All dependencies are installed" even if `reportlab` was missing, leading to runtime errors when trying to generate reports.

## Changes
- Added `'reportlab': 'reportlab'` to [get_required_packages()](cci:1://file:///d:/OSCG/locdo/LOOK_DGC/validate_deps.py:12:0-32:5) in [validate_deps.py](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/validate_deps.py:0:0-0:0).
- Added `'reportlab': 'reportlab'` to [required_packages](cci:1://file:///d:/OSCG/locdo/LOOK_DGC/validate_deps.py:12:0-32:5) dict in [launch_look_dgc.py](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/launch_look_dgc.py:0:0-0:0).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

I have verified that the validation scripts now correctly list `reportlab` as a required package.

- [x] Verified [validate_deps.py](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/validate_deps.py:0:0-0:0) includes `reportlab` in the required packages list.
- [x] Verified [launch_look_dgc.py](cci:7://file:///d:/OSCG/locdo/LOOK_DGC/launch_look_dgc.py:0:0-0:0) includes `reportlab` in its basic dependency check.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings