### PR TITLE
Fix PSNR-B calculation fail with NameError by vendoring psnrb

### DIFF
--- a/gui/comparison.py
+++ b/gui/comparison.py
@@ -30,6 +30,7 @@ from utility import (
     desaturate,
     butter_exe,
     ssimul_exe,
+    psnrb as psnrb_func,
 )
 from viewer import ImageViewer
 
@@ -392,11 +393,7 @@ class ComparisonWidget(ToolWidget):
         progress.setValue(6)
         if self.stopped:
             return
-        try:
-            psnrb = sewar.psnrb(img1, img2)
-        except NameError:
-            # FIXME: C'\`e un bug in psnrb (https://github.com/andrewekhalel/sewar/issues/17)
-            psnrb = 0
+        psnrb = psnrb_func(img1, img2)
         progress.setValue(7)
         if self.stopped:
             return

--- a/gui/repro_issue.py
+++ b/gui/repro_issue.py
@@ -1,0 +1,20 @@
+
+import numpy as np
+import sewar
+import traceback
+
+try:
+    img1 = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
+    img2 = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
+    # sewar expects (H, W, C) or (H, W)
+    # The fix in user request mentions copying psnrb to utility.py
+    
+    # Try running psnrb
+    val = sewar.psnrb(img1, img2)
+    print(f"PSNR-B: {val}")
+except NameError as e:
+    print("Caught NameError:")
+    traceback.print_exc()
+except Exception as e:
+    print(f"Caught {type(e).__name__}:")
+    traceback.print_exc()

--- a/gui/test_fix.py
+++ b/gui/test_fix.py
@@ -1,0 +1,24 @@
+
+import numpy as np
+import sys
+import os
+
+# Add gui folder to path
+sys.path.append(os.getcwd())
+
+from utility import psnrb
+import traceback
+
+try:
+    img1 = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
+    img2 = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
+    
+    # Try running local psnrb
+    val = psnrb(img1, img2)
+    print(f"Local PSNR-B: {val}")
+except NameError as e:
+    print("Caught NameError:")
+    traceback.print_exc()
+except Exception as e:
+    print(f"Caught {type(e).__name__}:")
+    traceback.print_exc()

--- a/gui/utility.py
+++ b/gui/utility.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from time import time
+from math import log10
 
 try:
     import rawpy
@@ -479,3 +480,104 @@ class ParamSlider(QWidget):
         self.spin.setValue(self.slider.value())
         self.slider.setValue(self.spin.value())
         self.valueChanged.emit(self.slider.value())
+
+
+def _compute_bef(im, block_size=8):
+    """Calculates Blocking Effect Factor (BEF) for a given grayscale/one channel image
+
+    C. Yim and A. C. Bovik, "Quality Assessment of Deblocked Images," in IEEE Transactions on Image Processing,
+        vol. 20, no. 1, pp. 88-98, Jan. 2011.
+
+    :param im: input image (numpy ndarray)
+    :param block_size: Size of the block over which DCT was performed during compression
+    :return: float -- bef.
+    """
+    if len(im.shape) == 3:
+        height, width, channels = im.shape
+    elif len(im.shape) == 2:
+        height, width = im.shape
+        channels = 1
+    else:
+        raise ValueError("Not a 1-channel/3-channel grayscale image")
+
+    if channels > 1:
+        raise ValueError("Not for color images")
+
+    h = np.array(range(0, width - 1))
+    h_b = np.array(range(block_size - 1, width - 1, block_size))
+    h_bc = np.array(list(set(h).symmetric_difference(h_b)))
+
+    v = np.array(range(0, height - 1))
+    v_b = np.array(range(block_size - 1, height - 1, block_size))
+    v_bc = np.array(list(set(v).symmetric_difference(v_b)))
+
+    d_b = 0
+    d_bc = 0
+
+    # h_b for loop
+    for i in list(h_b):
+        diff = im[:, i] - im[:, i+1]
+        d_b += np.sum(np.square(diff))
+
+    # h_bc for loop
+    for i in list(h_bc):
+        diff = im[:, i] - im[:, i+1]
+        d_bc += np.sum(np.square(diff))
+
+    # v_b for loop
+    for j in list(v_b):
+        diff = im[j, :] - im[j+1, :]
+        d_b += np.sum(np.square(diff))
+
+    # V_bc for loop
+    for j in list(v_bc):
+        diff = im[j, :] - im[j+1, :]
+        d_bc += np.sum(np.square(diff))
+
+    # N code
+    n_hb = height * (width/block_size) - 1
+    n_hbc = (height * (width - 1)) - n_hb
+    n_vb = width * (height/block_size) - 1
+    n_vbc = (width * (height - 1)) - n_vb
+
+    # D code
+    d_b /= (n_hb + n_vb)
+    d_bc /= (n_hbc + n_vbc)
+
+    # Log
+    if d_b > d_bc:
+        t = np.log2(block_size)/np.log2(min(height, width))
+    else:
+        t = 0
+
+    # BEF
+    bef = t*(d_b - d_bc)
+
+    return bef
+
+
+def psnrb(GT, P):
+    """Calculates PSNR with Blocking Effect Factor for a given pair of images (PSNR-B)
+
+    :param GT: first (original) input image in YCbCr format or Grayscale.
+    :param P: second (corrected) input image in YCbCr format or Grayscale..
+    :return: float -- psnr_b.
+    """
+    if len(GT.shape) == 3:
+        GT = GT[:, :, 0]
+
+    if len(P.shape) == 3:
+        P = P[:, :, 0]
+
+    imdff = np.double(GT) - np.double(P)
+
+    mse = np.mean(np.square(imdff.flatten()))
+    bef = _compute_bef(P)
+    mse_b = mse + bef
+
+    if np.amax(P) > 2:
+        psnr_b = 10 * log10(255**2/mse_b)
+    else:
+        psnr_b = 10 * log10(1/mse_b)
+
+    return psnr_b


### PR DESCRIPTION
issue: #48


**Description:** This PR fixes an issue where the PSNR-B (Peak Signal-to-Noise Ratio with Blocking effect) calculation was failing silently.


- The application was previously catching a NameError from the sewar library and setting the result to 0, which is a misleading value for image quality.
- The root cause was a known bug in the upstream sewar library where a variable name was misspelled.
- I have vendored the psnrb and _compute_bef functions from sewar into our local gui/utility.py file.
- I fixed the variable name typo in the local copy of the code to ensure it works correctly.
- I updated gui/comparison.py to use this local implementation instead of the broken library function.
- The PSNR-B metric now calculates correctly and displays the actual value instead of 0.