### PR TITLE
Fix #14: Add PyTorch dependencies for TruFor AI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ LOOK-DGC/
 - **🐍 Python 3.11+** 
 - **💾 4GB+ RAM** (recommended)
 - **🖥️ Windows/Linux/macOS**
+- **🤖 PyTorch** (automatically installed via `requirements.txt` - required for TruFor AI tool)
 
 ### 🚀 Method 1: Quick Start (Recommended)
 
@@ -297,6 +298,8 @@ source .venv/bin/activate
 cd gui
 pip install -r requirements.txt
 ```
+
+**✅ Note:** This installation includes PyTorch (`torch` and `torchvision`), which is required for the TruFor AI tool in the AI Solutions menu. If you want to use TruFor for AI-based tampering detection, ensure the installation completes successfully.
 
 Alternatively, you can use the automated dependency checker:
 

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -15,3 +15,5 @@ tensorflow==2.16.*
 xgboost==1.6.*
 pillow==10.3.*
 PyWavelets==1.5.*
+torch==2.3.*
+torchvision==0.18.*


### PR DESCRIPTION
Fixes #14

This PR resolves the missing PyTorch dependencies that were causing TruFor AI tool to fail.

Changes:
- Added torch==2.3.* and torchvision==0.18.* to gui/requirements.txt
- Fixed version compatibility between torch and torchvision
- Updated README.md to document PyTorch as a prerequisite
- Added installation note explaining PyTorch is needed for TruFor AI solutions